### PR TITLE
Hide #ui-datepicker-div on on fields setup.

### DIFF
--- a/js/timepicker.js
+++ b/js/timepicker.js
@@ -63,7 +63,7 @@
 				
 				if($('body > #ui-datepicker-div').length > 0)
 				{
-					$('#ui-datepicker-div').wrap('<div class="ui-acf" />');
+					$('#ui-datepicker-div').hide().wrap('<div class="ui-acf" />');
 				}
 
 				// allow null
@@ -136,7 +136,7 @@
 				
 				if($('body > #ui-datepicker-div').length > 0)
 				{
-					$('#ui-datepicker-div').wrap('<div class="ui-acf" />');
+					$('#ui-datepicker-div').hide().wrap('<div class="ui-acf" />');
 				}
 
 				// allow null


### PR DESCRIPTION
Hides the #ui-datepicker-div element on fields setup. Without it hidden, you get a thin white bar at the bottom of the page:

![](https://cloud.githubusercontent.com/assets/4213522/3932322/6dd3cc3e-2468-11e4-9085-5ec6fde68220.png)

Changes tested in ACF 4.3.8 and 5.0.4.