### PR TITLE
Add option to change step for minutes

### DIFF
--- a/date_time_picker-v5.php
+++ b/date_time_picker-v5.php
@@ -170,10 +170,10 @@ class acf_field_date_time_picker extends acf_field
 
 		if ( $field['show_date'] !== 'true' ) {
             $value = $field['save_as_timestamp'] && $this->isValidTimeStamp($field['value']) ? date_i18n(sprintf("%s",$this->js_to_php_timeformat($field['time_format'])), $field['value'])  : $field['value'];
-            echo '<input type="text" value="' . $value . '" name="' . $field['name'] . '" class="ps_timepicker" value="" data-picker="' . $field['picker'] . '" data-time_format="' . $field['time_format'] . '"  title="' . $field['label'] . '" />';
+            echo '<input type="text" value="' . $value . '" name="' . $field['name'] . '" class="ps_timepicker" value="" data-picker="' . $field['picker'] . '" data-time_format="' . $field['time_format'] . '" data-minute_step="' . $field['minute_step'] . '" title="' . $field['label'] . '" />';
         } else {
             $value = $field['save_as_timestamp'] && $this->isValidTimeStamp($field['value']) ? date_i18n(sprintf("%s %s", $this->js_to_php_dateformat($field['date_format']),$this->js_to_php_timeformat($field['time_format'])), $field['value'])  : $field['value'];
-            echo '<input type="text" value="' . $value . '" name="' . $field['name'] . '" class="ps_timepicker" value="" data-picker="' . $field['picker'] . '" data-date_format="' . $field['date_format'] . '" data-time_format="' . $field['time_format'] . '" data-show_week_number="' . $field['show_week_number'] . '"  title="' . $field['label'] . '" />';
+            echo '<input type="text" value="' . $value . '" name="' . $field['name'] . '" class="ps_timepicker" value="" data-picker="' . $field['picker'] . '" data-date_format="' . $field['date_format'] . '" data-time_format="' . $field['time_format'] . '" data-show_week_number="' . $field['show_week_number'] . '" data-minute_step="' . $field['minute_step'] . '" title="' . $field['label'] . '" />';
         }
     }
 

--- a/date_time_picker-v5.php
+++ b/date_time_picker-v5.php
@@ -28,6 +28,7 @@ class acf_field_date_time_picker extends acf_field
 			, 'picker'            => 'slider'
 			, 'save_as_timestamp' => 'true'
 			, 'get_as_timestamp'  => 'false'
+			, 'minute_step'       => 1
 		);
 
 		$this->version = '2.0.15';
@@ -83,6 +84,21 @@ class acf_field_date_time_picker extends acf_field
 			, 'instructions' => sprintf(__("eg. hh:mm. read more about <a href=\"%s\" target=\"_blank\">formatting  time</a>", $this->domain ),"http://trentrichardson.com/examples/timepicker/#tp-formatting")
 			, 'name'  => 'time_format'
 			, 'value' => $field['time_format']
+		) );
+
+		acf_render_field_setting( $field, array(
+			'type'       => 'select'
+			, 'label'    => __( "Minute Step", $this->domain )
+			, 'name'     => 'minute_step'
+			, 'value'    => $field['minute_step']
+			, 'choices' => array(
+					1          => __('1', $this->domain)
+				, 5          => __('5', $this->domain)
+				, 10         => __('10', $this->domain)
+				, 15         => __('15', $this->domain)
+				, 20         => __('20', $this->domain)
+				, 30         => __('30', $this->domain)
+			)
 		) );
 
 		acf_render_field_setting( $field, array(

--- a/js/timepicker.js
+++ b/js/timepicker.js
@@ -58,8 +58,8 @@
 					, dayNamesShort: timepicker_objectL10n.dayNamesShort
 					, dayNamesMin: timepicker_objectL10n.dayNamesMin
 					, firstDay: timepicker_objectL10n.firstDay
+					, stepMinute: parseInt(input.attr('data-minute_step'))
 				});
-
 				
 				if($('body > #ui-datepicker-div').length > 0)
 				{
@@ -131,9 +131,9 @@
 					, dayNamesShort: timepicker_objectL10n.dayNamesShort
 					, dayNamesMin: timepicker_objectL10n.dayNamesMin
 					, firstDay: timepicker_objectL10n.firstDay
+					, stepMinute: parseInt(input.attr('data-minute_step'))
 				});
 
-				
 				if($('body > #ui-datepicker-div').length > 0)
 				{
 					$('#ui-datepicker-div').wrap('<div class="ui-acf" />');


### PR DESCRIPTION
> Change step for minutes as people may want to limit minutes available for selection. For example, the slider minute options are 1, 5, 10, 15 and 30 minutes.

— [soderlind/acf-field-date-time-picker #86](soderlind/acf-field-date-time-picker/pull/86#issue-71058088)