### PR TITLE
Fixing repeater clone field initialization

### DIFF
--- a/js/timepicker.js
+++ b/js/timepicker.js
@@ -36,7 +36,7 @@
 					, has_ampm = (input.attr('data-time_format').search(/t/i) != -1);
 
 				//don't apply datepicker to clone field
-				if (input.parents('.acf-row.clone').length) {
+				if (input.parents('.acf-row.clone, .acf-row.acf-clone').length) {
 					return;
 				}
 


### PR DESCRIPTION
> Hello,
> 
> That is me again. Recently the clone field class was changed from "clone" to "acf-clone" which causes clone field to not work again.
> 
> As I am not working with ACF for quite some time I am not aware if there was no if there was no methods created to avoid such problems.
> 
> Anyway I have applied simple fix taking care of backwards compatibility as well.

— [soderlind/acf-field-date-time-picker #87](soderlind/acf-field-date-time-picker/pull/87#issue-71645343)